### PR TITLE
Add rules object.

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -53,6 +53,7 @@ library:
   - aeson
   - base64
   - bytestring
+  - containers
   - filepath
   - github-rest
   - process
@@ -94,6 +95,7 @@ tests:
     - QuickCheck
     - aeson
     - base64
+    - bytestring
     - github-rest
     - quickcheck-instances
     - text

--- a/src/Format.hs
+++ b/src/Format.hs
@@ -15,7 +15,7 @@ limitations under the License.
 -}
 
 -- |
--- Description: Format messages for GitHub
+-- Description: Format messages for GitHub.
 -- Copyright: Copyright 2023 Google LLC
 -- License: Apache-2.0
 -- Maintainer: chungyc@google.com

--- a/src/Rules.hs
+++ b/src/Rules.hs
@@ -1,0 +1,104 @@
+{-
+Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+-- |
+-- Description: Add rules for GitHub.
+-- Copyright: Copyright 2023 Google LLC
+-- License: Apache-2.0
+-- Maintainer: chungyc@google.com
+--
+-- At the time of writing, HLint does not add a separate @rules@ object
+-- because there is not much that it would add that is not already in the results.
+-- However, GitHub would use it for the title of a code scanning issue if available,
+-- which is frequently better than using the entire message when it is not available.
+--
+-- This module adds a @rules@ object to SARIF output if it does not already exist.
+-- It will use the rule ID as the name of the rule,
+-- which GitHub will use as the title of an issue.
+--
+-- It would have been nice to include the notes in full descriptions.
+-- However, we should not because there can be multiple hints
+-- with the same name but different notes.
+module Rules (add) where
+
+import Data.Aeson
+import Data.Aeson.KeyMap hiding (map)
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Vector qualified as Vector
+import Prelude hiding (lookup)
+
+-- | If a @sarifLog@ object does not have a @rules@ object
+-- in a @driver@ object inside a @tool@ object, add one based on the results.
+-- This will make the code scanning issue titles in GitHub more tidy.
+add :: Value -> Value
+add (Object v) = Object $ mapWithKey addRulesToRuns v
+  where
+    addRulesToRuns "runs" (Array us) = Array $ fmap addRulesToRun us
+    addRulesToRuns _ u = u
+
+    addRulesToRun (Object u)
+      | member "tool" u = Object $ mapWithKey addRulesToTool u
+      | otherwise =
+          Object $
+            insert
+              "tool"
+              ( Object . singleton "driver" $
+                  Object . singleton "rules" $
+                    rulesArray
+              )
+              u
+    addRulesToRun u = u
+
+    addRulesToTool "tool" (Object u)
+      | member "driver" u = Object $ mapWithKey addRulesToDriver u
+      | otherwise = Object $ insert "driver" (Object $ singleton "rules" rulesArray) u
+    addRulesToTool _ u = u
+
+    addRulesToDriver "driver" o@(Object u)
+      | member "rules" u = o
+      | otherwise = Object $ insert "rules" rulesArray u
+    addRulesToDriver _ u = u
+
+    rules = Set.unions $ mapWithKey getRulesFromRuns v
+    rulesArray = Array $ Vector.fromList $ map formatRule $ Set.toList rules
+
+    getRulesFromRuns "runs" (Array us) = Set.unions $ fmap getRulesFromRun us
+    getRulesFromRuns _ _ = Set.empty
+
+    getRulesFromRun (Object u) = Set.unions $ mapWithKey getRulesFromResults u
+    getRulesFromRun _ = Set.empty
+
+    getRulesFromResults "results" (Array us) = Set.unions $ fmap getRulesFromResult us
+    getRulesFromResults _ _ = Set.empty
+
+    getRulesFromResult (Object u)
+      | Just (String r) <- lookup "ruleId" u = Set.singleton r
+      | otherwise = Set.empty
+    getRulesFromResult _ = Set.empty
+add v = v
+
+-- | Formats a object which will be placed in a @rules@ object.
+-- Basically the minimum that GitHub requires,
+-- although we cannot do much more than use the hint name everywhere.
+formatRule :: Text -> Value
+formatRule ruleId =
+  Object . fromList $
+    [ ("id", String ruleId),
+      ("name", String ruleId),
+      ("shortDescription", Object $ singleton "text" $ String ruleId),
+      ("fullDescription", Object $ singleton "text" $ String ruleId)
+    ]

--- a/test/RulesSpec.hs
+++ b/test/RulesSpec.hs
@@ -1,0 +1,227 @@
+{-
+Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+-- |
+-- Description: Tests for the "Rules" module.
+-- Copyright: Copyright 2023 Google LLC
+-- License: Apache-2.0
+-- Maintainer: chungyc@google.com
+module RulesSpec (spec) where
+
+import Data.Aeson
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.Text qualified as Text
+import Data.Vector qualified as Vector
+import Rules
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "add" $ do
+    it "adds rules when there was no tool object" $
+      add
+        ( Object . KeyMap.singleton "runs" $
+            Array . Vector.fromList $
+              [ Object . KeyMap.singleton "results" . Array . Vector.fromList $
+                  [ Object . KeyMap.fromList $
+                      [ ("ruleId", String "use 1")
+                      ],
+                    Object . KeyMap.fromList $
+                      [ ("ruleId", String "use 2"),
+                        ( "message",
+                          Object . KeyMap.singleton "text" . String $
+                            Text.unlines
+                              [ "Some warning",
+                                "Found:",
+                                "  not (x-y < 0 || x-y > 0)",
+                                "Perhaps:",
+                                "  x == y",
+                                "Note: this is just better"
+                              ]
+                        )
+                      ]
+                  ]
+              ]
+        )
+        `shouldBe` Object
+          ( KeyMap.singleton "runs" $
+              Array . Vector.singleton . Object . KeyMap.fromList $
+                [ ( "tool",
+                    Object . KeyMap.singleton "driver" $
+                      Object . KeyMap.singleton "rules" $
+                        Array . Vector.fromList $
+                          [ Object . KeyMap.fromList $
+                              [ ("id", String "use 1"),
+                                ("name", String "use 1"),
+                                ( "shortDescription",
+                                  Object $ KeyMap.singleton "text" $ String "use 1"
+                                ),
+                                ( "fullDescription",
+                                  Object $ KeyMap.singleton "text" $ String "use 1"
+                                )
+                              ],
+                            Object . KeyMap.fromList $
+                              [ ("id", String "use 2"),
+                                ("name", String "use 2"),
+                                ( "shortDescription",
+                                  Object . KeyMap.singleton "text" $ String "use 2"
+                                ),
+                                ( "fullDescription",
+                                  Object . KeyMap.singleton "text" $ String "use 2"
+                                )
+                              ]
+                          ]
+                  ),
+                  ( "results",
+                    Array . Vector.fromList $
+                      [ Object . KeyMap.fromList $
+                          [ ("ruleId", String "use 1")
+                          ],
+                        Object . KeyMap.fromList $
+                          [ ("ruleId", String "use 2"),
+                            ( "message",
+                              Object . KeyMap.singleton "text" . String $
+                                Text.unlines
+                                  [ "Some warning",
+                                    "Found:",
+                                    "  not (x-y < 0 || x-y > 0)",
+                                    "Perhaps:",
+                                    "  x == y",
+                                    "Note: this is just better"
+                                  ]
+                            )
+                          ]
+                      ]
+                  )
+                ]
+          )
+
+    it "adds rules when there was no driver object" $
+      add
+        ( Object . KeyMap.singleton "runs" $
+            Array . Vector.fromList $
+              [ Object . KeyMap.fromList $
+                  [ ( "tool",
+                      Object . KeyMap.singleton "extensions" . Array . Vector.singleton $
+                        Object . KeyMap.singleton "name" $
+                          String "random extension"
+                    ),
+                    ( "results",
+                      Array . Vector.fromList $
+                        [ Object . KeyMap.fromList $
+                            [ ("ruleId", String "use 1")
+                            ]
+                        ]
+                    )
+                  ]
+              ]
+        )
+        `shouldBe` Object
+          ( KeyMap.singleton "runs" $
+              Array . Vector.singleton . Object . KeyMap.fromList $
+                [ ( "tool",
+                    Object . KeyMap.fromList $
+                      [ ( "driver",
+                          Object . KeyMap.singleton "rules" $
+                            Array . Vector.fromList $
+                              [ Object . KeyMap.fromList $
+                                  [ ("id", String "use 1"),
+                                    ("name", String "use 1"),
+                                    ( "shortDescription",
+                                      Object $ KeyMap.singleton "text" $ String "use 1"
+                                    ),
+                                    ( "fullDescription",
+                                      Object $ KeyMap.singleton "text" $ String "use 1"
+                                    )
+                                  ]
+                              ]
+                        ),
+                        ( "extensions",
+                          Array . Vector.singleton $
+                            Object . KeyMap.singleton "name" $
+                              String "random extension"
+                        )
+                      ]
+                  ),
+                  ( "results",
+                    Array . Vector.fromList $
+                      [ Object . KeyMap.fromList $
+                          [("ruleId", String "use 1")]
+                      ]
+                  )
+                ]
+          )
+
+    it "does not overwrite existing rules" $
+      add
+        ( Object . KeyMap.singleton "runs" $
+            Array . Vector.fromList $
+              [ Object . KeyMap.fromList $
+                  [ ( "tool",
+                      Object . KeyMap.singleton "driver" . Object $
+                        KeyMap.singleton "rules" . Array . Vector.fromList $
+                          [ Object . KeyMap.fromList $
+                              [ ("id", String "use 1"),
+                                ("name", String "The first rule"),
+                                ( "shortDescription",
+                                  Object $ KeyMap.singleton "text" $ String "See rule 1"
+                                ),
+                                ( "fullDescription",
+                                  Object $ KeyMap.singleton "text" $ String "Really see rule 1"
+                                )
+                              ]
+                          ]
+                    ),
+                    ( "results",
+                      Array . Vector.fromList $
+                        [ Object . KeyMap.fromList $
+                            [ ("ruleId", String "use 1")
+                            ]
+                        ]
+                    )
+                  ]
+              ]
+        )
+        `shouldBe` Object
+          ( KeyMap.singleton "runs" $
+              Array . Vector.singleton . Object . KeyMap.fromList $
+                [ ( "tool",
+                    Object . KeyMap.fromList $
+                      [ ( "driver",
+                          Object . KeyMap.singleton "rules" $
+                            Array . Vector.fromList $
+                              [ Object . KeyMap.fromList $
+                                  [ ("id", String "use 1"),
+                                    ("name", String "The first rule"),
+                                    ( "shortDescription",
+                                      Object $ KeyMap.singleton "text" $ String "See rule 1"
+                                    ),
+                                    ( "fullDescription",
+                                      Object $ KeyMap.singleton "text" $ String "Really see rule 1"
+                                    )
+                                  ]
+                              ]
+                        )
+                      ]
+                  ),
+                  ( "results",
+                    Array . Vector.fromList $
+                      [ Object . KeyMap.fromList $
+                          [("ruleId", String "use 1")]
+                      ]
+                  )
+                ]
+          )


### PR DESCRIPTION
This will add the rules object for better code scanning dashboards in GitHub.  It will not make much sense for a general rules object beyond this purpose, which is why it is part of the GitHub action and not in HLint.