### PR TITLE
Update to an LTS version of Stack.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,12 @@
 # syntax=docker/dockerfile:1
 
-# We fetch and build a specific unreleased version of HLint as well,
-# since a version of HLint with SARIF support has not been released yet.
-#
-# Once one has been, we may either continue to bundle the hlint binary
-# together but at a more stable and official set of versions.
-# Alternatively, we could have the action retrieve an hlint release
-# automatically if one is not already available locally in the action.
-
-FROM haskell:9.8.1-buster@sha256:0d951e083ab7089d8de9ec0e5eb142eaefd70ec6b1de7d5da8a38d16afec38f1 AS build
+FROM haskell:9.4.8-buster AS build
 RUN git clone https://github.com/haskell-actions/hlint-scan.git /src/hlint-scan
 WORKDIR /src/hlint-scan
 RUN stack install hlint hlint-scan:exe:hlint-scan && \
     cp "$(stack path --local-bin)/hlint" "$(stack path --local-bin)/hlint-scan" /
 
-FROM debian:buster-slim@sha256:8e5da7fd9aef8c0b3f23bb8c3f391667b50929984b7daa666ea1c7730f3b73b9
+FROM debian:buster-slim
 RUN apt-get --yes update && \
     apt-get --yes --no-install-recommends install ca-certificates=20200601~deb10u2 && \
     apt-get --yes clean && \

--- a/stack.yaml
+++ b/stack.yaml
@@ -19,17 +19,14 @@
 # Resolver to choose a 'specific' stackage snapshot or a compiler version.
 # Use a nightly build for now so that we can build an unreleased version
 # of HLint with SARIF support.
-resolver: nightly-2023-05-02
+resolver: lts-21.24
 
 # User packages to be built.
 packages:
 - .
 
 # Dependency packages to be pulled from upstream that are not in the resolver.
-extra-deps:
-  # For unreleased version with SARIF support.
-- git: https://github.com/ndmitchell/hlint.git
-  commit: 8a42c0fea7fa9b9a7e046b9de1f7ef90a03a1401
+# extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
Recent LTS releases include a sufficiently recent HLint.

Change Haskell Docker image version to match GHC version.